### PR TITLE
Cleaning Up share-links.html

### DIFF
--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -9,13 +9,6 @@
         </a>
       </li>
   
-      <!-- Google Plus -->
-      <li>
-        <a href="//plus.google.com/share?url={{ .Permalink }}" target="_blank" title="Share on Google Plus">
-          <i class="fab fa-google-plus"></i>
-        </a>
-      </li>
-  
       <!-- Facebook -->
       <li>
         <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Share on Facebook">
@@ -29,18 +22,18 @@
           <i class="fab fa-reddit"></i>
         </a>
       </li>
-  
+
+      <!-- Hacker News -->
+      <li>
+        <a href="//news.ycombinator.com/submitlink?u={{ .Permalink }}&t={{ .Title }}" target="_blank" title="Share on Hacker News">
+          <i class="fab fa-hacker-news"></i>
+        </a>
+      </li>
+
       <!-- LinkedIn -->
       <li>
         <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on LinkedIn">
           <i class="fab fa-linkedin"></i>
-        </a>
-      </li>
-  
-      <!-- StumbleUpon -->
-      <li>
-        <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on StumbleUpon">
-          <i class="fab fa-stumbleupon"></i>
         </a>
       </li>
   


### PR DESCRIPTION
Adding Hacker News
Removed G+ (it's dead/dying) and StumbleUpon (it's Mix)

Signed-off-by: Chris Short <chris@chrisshort.net>